### PR TITLE
Support MidiQOL reaction types

### DIFF
--- a/scripts/dnd5e/MonsterBlock5e.js
+++ b/scripts/dnd5e/MonsterBlock5e.js
@@ -1194,7 +1194,14 @@ export default class MonsterBlock5e extends dnd5e.applications.actor.ActorSheet5
 	}
 
 	static isReaction(item) {
-		return item.system?.activation?.type === "reaction";
+		return [
+			// dnd5e
+			"reaction",
+			// midi-qol
+			"reactionpreattack",
+			"reactiondamage",
+			"reactionmanual",
+		].includes(item.system?.activation?.type);
 	}
 
 


### PR DESCRIPTION
This enables the display of MidiQOL's extra reaction types, which are otherwise missing from the sheet.

See: https://gitlab.com/tposney/midi-qol/-/blob/dnd3/src/midi-qol.ts?ref_type=heads#L376

---

More details: https://github.com/zeel01/MonsterBlocks/pull/237

I have since been told this is the "active" fork, so, mirroring the PR here